### PR TITLE
fix: Пробрасывать sdkMeta в сообщения в window.appInitialData

### DIFF
--- a/src/dev.ts
+++ b/src/dev.ts
@@ -223,6 +223,7 @@ export const initializeAssistantSDK = ({
         await vpsClient.sendSystemMessage({ data: {}, messageName: 'OPEN_ASSISTANT' });
 
         if (initPhrase) {
+            const messageId = vpsClient.currentMessageId;
             const res = await vpsClient.sendText(initPhrase);
             appInfo = res?.app_info;
             if (res?.character) {
@@ -232,7 +233,7 @@ export const initializeAssistantSDK = ({
 
             for (const item of res?.items || []) {
                 if (item.command != null) {
-                    initialSmartAppData.push(item.command);
+                    initialSmartAppData.push({ ...item.command, sdkMeta: { mid: messageId } });
                 }
             }
 


### PR DESCRIPTION
Closes: #55
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.1-canary.56.77d9ddf0032ef997caf6b9132fe21d359ded30aa.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@2.0.1-canary.56.77d9ddf0032ef997caf6b9132fe21d359ded30aa.0
  # or 
  yarn add @sberdevices/assistant-client@2.0.1-canary.56.77d9ddf0032ef997caf6b9132fe21d359ded30aa.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
