### PR TITLE
Fix: воспроизведение озвучки из буфера при остановленном плеере

### DIFF
--- a/src/createVoicePlayer.ts
+++ b/src/createVoicePlayer.ts
@@ -368,6 +368,9 @@ export const createVoicePlayer = ({
             tracks.getByIndex(cursor).stop();
             cursor++;
         }
+
+        ctx?.close();
+        ctx = null;
     };
 
     return {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.1-canary.59.512fa8aef00f263236e660625d2208293d6b4372.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@2.2.1-canary.59.512fa8aef00f263236e660625d2208293d6b4372.0
  # or 
  yarn add @sberdevices/assistant-client@2.2.1-canary.59.512fa8aef00f263236e660625d2208293d6b4372.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
