### PR TITLE
fix: Воспроизведение пустой озвучки

### DIFF
--- a/src/createVoicePlayer.ts
+++ b/src/createVoicePlayer.ts
@@ -191,6 +191,10 @@ const createTrackStream = (
 
         firstChunk = false;
 
+        if (slicePoint >= data.length) {
+            return;
+        }
+
         getExtraBytes(data, bytesArraysSizes);
 
         const dataBuffer = new ArrayBuffer(bytesArraysSizes.incomingMessageVoiceDataLength);


### PR DESCRIPTION
Господа из сбера, пофиксите плиз, при работе со своими звуками и удалении текста ассистента, на локалке не возможно работать...
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.4.2-canary.72.f61261ca3bfc7f81c3b27a66b52c2fabd0b6b1c1.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@2.4.2-canary.72.f61261ca3bfc7f81c3b27a66b52c2fabd0b6b1c1.0
  # or 
  yarn add @sberdevices/assistant-client@2.4.2-canary.72.f61261ca3bfc7f81c3b27a66b52c2fabd0b6b1c1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
