### PR TITLE
fix: мета в intialSettings

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -80,6 +80,7 @@ export const createClient = (clientParams: CreateClientDataType, logger?: Client
         version,
         messageName,
         vpsToken,
+        meta,
     } = clientParams;
     const basePayload = compileBasePayload({ userId, token, messageName, vpsToken, userChannel, version });
 
@@ -173,7 +174,12 @@ export const createClient = (clientParams: CreateClientDataType, logger?: Client
         });
     };
 
-    const sendInitialSettings = (data: IInitialSettings, last = true, messageId = getMessageId()) => {
+    const sendInitialSettings = (
+        data: IInitialSettings,
+        last = true,
+        messageId = getMessageId(),
+        params: { meta?: { [k: string]: string } } = {},
+    ) => {
         if (data.device && data.settings) {
             currentSettings = {
                 ...currentSettings,
@@ -187,6 +193,7 @@ export const createClient = (clientParams: CreateClientDataType, logger?: Client
             payload: {
                 initialSettings: InitialSettings.create(data),
                 last: last ? 1 : -1,
+                ...params,
             },
             messageId,
         });
@@ -323,13 +330,18 @@ export const createClient = (clientParams: CreateClientDataType, logger?: Client
                     }
                     sendSettings(currentSettings.settings);
                 } else {
-                    sendInitialSettings({
-                        userId,
-                        userChannel,
-                        device: currentSettings.device,
-                        settings: currentSettings.settings,
-                        locale: version > 3 ? currentSettings.locale : undefined,
-                    });
+                    sendInitialSettings(
+                        {
+                            userId,
+                            userChannel,
+                            device: currentSettings.device,
+                            settings: currentSettings.settings,
+                            locale: version > 3 ? currentSettings.locale : undefined,
+                        },
+                        true,
+                        undefined,
+                        { meta },
+                    );
                 }
 
                 logger?.logInit({ ...clientParams, ...currentSettings });

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -403,6 +403,7 @@ export type CreateClientDataType = {
     version: VpsVersion;
     messageName?: string;
     vpsToken?: string;
+    meta?: { [k: string]: string };
 };
 
 export interface IncomingMessage {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.9.4-canary.86.f67a998f06d936633336655947b52ad2afc6c772.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@2.9.4-canary.86.f67a998f06d936633336655947b52ad2afc6c772.0
  # or 
  yarn add @sberdevices/assistant-client@2.9.4-canary.86.f67a998f06d936633336655947b52ad2afc6c772.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
