### PR TITLE
fix: Дублирование сообщений из appInitialData

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ interface AssistantCharacterCommand {
   character: {
     id: "sber" | "eva" | "joy";
   };
-  sdkMeta: {
+  sdk_meta: {
     requestId: string;
   };
 }
@@ -338,7 +338,7 @@ interface AssistantNavigationCommand {
   type: "navigation";
   // Навигационная команда (направление навигации)
   navigation: { command: "UP" | "DOWN" | "LEFT" | "RIGHT" | "FORWARD" | "BACK" };
-  sdkMeta: {
+  sdk_meta: {
     requestId: string;
   };
 }
@@ -387,7 +387,7 @@ interface AssistantSmartAppCommand {
     // Любые данные, которые нужны смартапу
     payload: Record<string, unknown>;
   };
-  sdkMeta: {
+  sdk_meta: {
     requestId: string;
   };
 }

--- a/cypress/integration/createAssistant.spec.ts
+++ b/cypress/integration/createAssistant.spec.ts
@@ -132,7 +132,7 @@ describe('Проверяем createAssistant', () => {
         // не передаем requestId, ожидаем ответ
         window.AssistantHost.sendDataContainer = (data) => {
             const { requestId } = JSON.parse(data);
-            setTimeout(() => window.AssistantClient.onData({ ...command, sdkMeta: { requestId } }));
+            setTimeout(() => window.AssistantClient.onData({ ...command, sdk_meta: { requestId } }));
         };
         assistant.sendData({ action }, (cmd) => {
             expect(cmd).to.deep.equal(command);
@@ -143,9 +143,9 @@ describe('Проверяем createAssistant', () => {
         });
 
         // передаем requestId, ожидаем ответ
-        assistant.sendData({ action, requestId }, ({ sdkMeta, ...cmd }) => {
+        assistant.sendData({ action, requestId }, ({ sdk_meta, ...cmd }) => {
             expect(cmd).to.deep.equal(command);
-            expect(sdkMeta?.requestId).to.equal(requestId);
+            expect(sdk_meta?.requestId).to.equal(requestId);
             status.second = true;
             if (status.first) {
                 done();

--- a/cypress/integration/sendAction.spec.ts
+++ b/cypress/integration/sendAction.spec.ts
@@ -66,7 +66,7 @@ describe('Проверяем sendAction', () => {
         window.AssistantHost.sendDataContainer = (data) => {
             const { requestId } = JSON.parse(data);
             setTimeout(() =>
-                commands.map((command) => window.AssistantClient.onData({ ...command, sdkMeta: { requestId } })),
+                commands.map((command) => window.AssistantClient.onData({ ...command, sdk_meta: { requestId } })),
             );
         };
 
@@ -99,7 +99,7 @@ describe('Проверяем sendAction', () => {
             const { requestId } = JSON.parse(data);
             setTimeout(() =>
                 commands.map((command, i) =>
-                    setTimeout(() => window.AssistantClient.onData({ ...command, sdkMeta: { requestId } }), i),
+                    setTimeout(() => window.AssistantClient.onData({ ...command, sdk_meta: { requestId } }), i),
                 ),
             );
         };

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -237,7 +237,7 @@ export const initializeAssistantSDK = ({
             initialSmartAppData.push({
                 type: 'insets',
                 insets: { left: 0, top: 0, right: 0, bottom: 144 },
-                sdkMeta: { mid: -1 },
+                sdk_meta: { mid: -1 },
             });
 
             const messageId = vpsClient.currentMessageId;
@@ -250,7 +250,7 @@ export const initializeAssistantSDK = ({
 
             for (const item of res?.items || []) {
                 if (item.command != null) {
-                    initialSmartAppData.push({ ...item.command, sdkMeta: { mid: messageId } });
+                    initialSmartAppData.push({ ...item.command, sdk_meta: { mid: messageId } });
                 }
             }
 
@@ -435,14 +435,14 @@ export const initializeAssistantSDK = ({
 
                 emitOnData({
                     ...item.command,
-                    sdkMeta: { mid: original.messageId, requestId: requestIdMap[original.messageId.toString()] },
+                    sdk_meta: { mid: original.messageId, requestId: requestIdMap[original.messageId.toString()] },
                 });
             }
         }
 
         if (message.character && message.character.id !== character) {
             character = message.character.id;
-            emitOnData({ type: 'character', character: message.character, sdkMeta: { mid: -1 } });
+            emitOnData({ type: 'character', character: message.character, sdk_meta: { mid: -1 } });
         }
 
         updateDevUI(message.suggestions?.buttons ?? [], bubbleText);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/camelcase */
+
 import { v4 } from 'uuid';
 
 import {
@@ -60,8 +62,8 @@ export const createAssistant = <A extends AssistantSmartAppData>({
                     index = initialData.findIndex((c) => c.type === 'insets');
                 } else if (command.type === 'app_context') {
                     index = initialData.findIndex((c) => c.type === 'app_context');
-                } else if (command.sdkMeta && command.sdkMeta?.mid && command.sdkMeta?.mid !== '-1') {
-                    index = initialData.findIndex((c) => c.sdkMeta?.mid === command.sdkMeta.mid);
+                } else if (command.sdk_meta && command.sdk_meta?.mid && command.sdk_meta?.mid !== '-1') {
+                    index = initialData.findIndex((c) => c.sdk_meta?.mid === command.sdk_meta.mid);
                 }
 
                 if (index >= 0) {
@@ -72,18 +74,18 @@ export const createAssistant = <A extends AssistantSmartAppData>({
 
             if (
                 (command.type === 'smart_app_data' || command.type === 'smart_app_error') &&
-                command.sdkMeta?.requestId &&
-                observables.has(command.sdkMeta.requestId)
+                command.sdk_meta?.requestId &&
+                observables.has(command.sdk_meta.requestId)
             ) {
-                const { sdkMeta, ...other } = command;
-                const { requestId: realReqId, ...meta } = sdkMeta;
+                const { sdk_meta, ...other } = command;
+                const { requestId: realReqId, ...meta } = sdk_meta;
                 const result = other;
-                const { requestId, next } = observables.get(command.sdkMeta.requestId);
+                const { requestId, next } = observables.get(command.sdk_meta.requestId);
 
                 if (Object.keys(meta).length > 0 || requestId) {
-                    result.sdkMeta = { ...meta };
+                    result.sdk_meta = { ...meta };
                     if (requestId) {
-                        result.sdkMeta = { requestId };
+                        result.sdk_meta = { requestId };
                     }
                 }
                 next(result);

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -136,7 +136,7 @@ export interface AssistantCharacterCommand {
     character: {
         id: AssistantCharacterType;
     };
-    sdkMeta: SdkMeta;
+    sdk_meta: SdkMeta;
 }
 
 export interface AssistantInsetsCommand {
@@ -147,7 +147,7 @@ export interface AssistantInsetsCommand {
         right: number; // px
         bottom: number; // px
     };
-    sdkMeta: SdkMeta;
+    sdk_meta: SdkMeta;
 }
 
 export interface AssistantCloseAppCommand {
@@ -157,13 +157,13 @@ export interface AssistantCloseAppCommand {
 export interface AssistantNavigationCommand {
     type: 'navigation';
     navigation: { command: 'UP' | 'DOWN' | 'LEFT' | 'RIGHT' | 'BACK' | 'FORWARD' };
-    sdkMeta?: SdkMeta;
+    sdk_meta?: SdkMeta;
 }
 
 export interface AssistantSmartAppData {
     type: 'smart_app_data';
     smart_app_data?: Record<string, unknown>;
-    sdkMeta?: SdkMeta;
+    sdk_meta?: SdkMeta;
 }
 
 export interface AssistantSmartAppError {
@@ -172,7 +172,7 @@ export interface AssistantSmartAppError {
         code: number;
         description: string;
     };
-    sdkMeta?: SdkMeta;
+    sdk_meta?: SdkMeta;
 }
 
 export interface AssistantSmartAppCommand extends AssistantSmartAppData {
@@ -180,7 +180,7 @@ export interface AssistantSmartAppCommand extends AssistantSmartAppData {
         type: string;
         payload: Record<string, unknown>;
     };
-    sdkMeta?: SdkMeta;
+    sdk_meta?: SdkMeta;
 }
 
 export interface AppInfo {
@@ -201,7 +201,7 @@ export interface AppInfo {
 export interface AssistantAppContext {
     type: 'app_context';
     app_context: AppInfo;
-    sdkMeta?: SdkMeta;
+    sdk_meta?: SdkMeta;
 }
 
 export interface AssistantPlayerCommand {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.11.5-canary.104.ffe2f649cf45d6178a95459d479dd53d47676c8a.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@2.11.5-canary.104.ffe2f649cf45d6178a95459d479dd53d47676c8a.0
  # or 
  yarn add @sberdevices/assistant-client@2.11.5-canary.104.ffe2f649cf45d6178a95459d479dd53d47676c8a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
