### PR TITLE
fix: Удобная обработка истекшего токена

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -117,6 +117,10 @@ export const createClient = (clientParams: CreateClientDataType, logger?: Client
         return sendSettingsOriginal(data, ...args);
     }) as typeof sendSettingsOriginal;
 
+    const setToken = (nextToken: CreateClientDataType['token']) => {
+        updateDefaults({ token: nextToken });
+    };
+
     const destroy = () => {
         destroyed = true;
         ws && ws.close();
@@ -215,6 +219,10 @@ export const createClient = (clientParams: CreateClientDataType, logger?: Client
 
             emit('message', message);
 
+            if (message.status && message.status.code === -45) {
+                emit('tokenExpired', message.status);
+            }
+
             if (message.systemMessage?.data) {
                 const systemMessage = JSON.parse(message.systemMessage.data);
                 emit('systemMessage', systemMessage, message);
@@ -238,6 +246,7 @@ export const createClient = (clientParams: CreateClientDataType, logger?: Client
         updateDefaults,
         destroy,
         batch,
+        setToken,
         get currentMessageId() {
             return currentMessageId;
         },

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -288,6 +288,7 @@ export type EventsType = {
     ready: () => void;
     close: () => void;
     message: (message: OriginalMessageType) => void;
+    tokenExpired: (status: OriginalMessageType['status']) => void;
     systemMessage: (systemMessageData: SystemMessageDataType, originalMessage: OriginalMessageType) => void;
     outcoming: (message: OriginalMessageType) => void;
 };


### PR DESCRIPTION
Возможность обработки и подмены токена уже была:

```js

const client = createClient({...});

client.on('message', ({ status }) => {
   if (status && status.code === -45) {
      client.updateDefaults({ token: newToken });
   }
});

```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.14.1--canary.118.7b31056ef207f2fe9a88fc885a913c004a7e211a.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@2.14.1--canary.118.7b31056ef207f2fe9a88fc885a913c004a7e211a.0
  # or 
  yarn add @sberdevices/assistant-client@2.14.1--canary.118.7b31056ef207f2fe9a88fc885a913c004a7e211a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
