### PR TITLE
fix: updated typing.ts same as .proto

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -260,6 +260,7 @@ export interface Device {
     deviceManufacturer?: string | null;
     deviceModel?: string | null;
     additionalInfo?: string | null;
+    tenant?: string | null;
 }
 
 export interface LegacyDevice {
@@ -393,6 +394,7 @@ export interface OriginalMessageType {
         settings?: Settings | null;
         locale?: string | null;
     } | null;
+    cancel?: {} | null;
     device?: Device | null;
     legacyDevice?: LegacyDevice | null;
     settings?: Settings | null;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.15.2--canary.124.4bd9bbfe8a19b608c7d7b77e0a91dbbe691d5b71.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@2.15.2--canary.124.4bd9bbfe8a19b608c7d7b77e0a91dbbe691d5b71.0
  # or 
  yarn add @sberdevices/assistant-client@2.15.2--canary.124.4bd9bbfe8a19b608c7d7b77e0a91dbbe691d5b71.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
