### PR TITLE
fix: Отправка systemMessage после запроса на пермишены

### DIFF
--- a/src/assistant/assistant.ts
+++ b/src/assistant/assistant.ts
@@ -198,10 +198,8 @@ export const createAssistant = ({ getMeta, ...configuration }: VpsConfiguration 
         appInfo: AppInfo,
         items: PermissionType[],
     ) => {
-        client.sendData({
-            data: await getAnswerForRequestPermissions(requestMessageId, appInfo, items),
-            messageName: 'SERVER_ACTION',
-        });
+        const data = await getAnswerForRequestPermissions(requestMessageId, appInfo, items);
+        client.sendData(data, 'SERVER_ACTION');
     };
 
     subscriptions.push(protocol.on('ready', () => emit('vps', { type: 'ready' })));


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.0.2--canary.175.ea34ac813a11a2362c5f826d20ebfca166e96ca9.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@4.0.2--canary.175.ea34ac813a11a2362c5f826d20ebfca166e96ca9.0
  # or 
  yarn add @sberdevices/assistant-client@4.0.2--canary.175.ea34ac813a11a2362c5f826d20ebfca166e96ca9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
