### PR TITLE
feat: Добавлен метод sendText для AssistantHost в типах

### DIFF
--- a/src/createAssistant.ts
+++ b/src/createAssistant.ts
@@ -291,6 +291,7 @@ export const createAssistant = <A extends AssistantSmartAppData>({
         },
         setSuggests: (suggest: string) => window.AssistantHost?.setSuggests(suggest),
         setHints: (hints: string) => window.AssistantHost?.setHints(hints),
+        sendText: (message: string) => window.AssistantHost?.sendText(message),
         ready: () => window.AssistantHost?.ready(),
     };
 };

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -156,8 +156,8 @@ export const initializeAssistantSDK = ({
     let assistantReady = false; // флаг готовности контекста ассистента
     let character: CharacterId;
 
-    const sendText = (text: string) => {
-        assistant.sendText(text);
+    const sendText = (messasge: string) => {
+        assistant.sendText(messasge);
     };
 
     const emitOnData = (command: AssistantClientCommand) => {
@@ -248,6 +248,7 @@ export const initializeAssistantSDK = ({
         },
         setSuggests() {},
         setHints() {},
+        sendText,
     };
 
     const subscribeToListenerStatus = (cb: (event: 'listen' | 'stopped') => void): (() => void) =>

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -237,6 +237,7 @@ export interface AssistantHost {
     ready: () => void;
     sendData: (action: string, message: string | null) => void;
     sendDataContainer: (container: string) => void;
+    sendText: (message: string) => void;
     setSuggests: (suggest: string) => void;
     setHints: (hints: string) => void;
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.6.0--canary.196.056d4062ccef39e511acf5ab5ed7f888f313dfd2.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@4.6.0--canary.196.056d4062ccef39e511acf5ab5ed7f888f313dfd2.0
  # or 
  yarn add @sberdevices/assistant-client@4.6.0--canary.196.056d4062ccef39e511acf5ab5ed7f888f313dfd2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
