### PR TITLE
fix: Стек initialCommands теперь формируется при window.AssistantClient.onStart()

### DIFF
--- a/cypress/integration/createAssistant.spec.ts
+++ b/cypress/integration/createAssistant.spec.ts
@@ -259,4 +259,32 @@ describe('Проверяем createAssistant', () => {
             expect(onData).to.callCount(initialData.length);
         }, 1);
     });
+
+    it('Не эмитить дважды команды из window.appInitialData', () => {
+        const initialSmartAppData = [
+            {
+                type: 'insets',
+                insets: { left: 0, top: 0, right: 0, bottom: 144 },
+                sdk_meta: { mid: '-1' },
+            },
+            {
+                type: 'character',
+                character: { id: 'sber' },
+                sdk_meta: { mid: '-1' },
+            },
+        ];
+
+        const onData = cy.stub();
+        const assistant = initAssistant();
+
+        assistant.on('data', onData);
+
+        window.appInitialData = [...initialSmartAppData];
+
+        for (const smartAppData of initialSmartAppData) {
+            window.AssistantClient.onData(smartAppData);
+        }
+
+        initialSmartAppData.forEach((command) => expect(onData).to.calledWith(command));
+    });
 });

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -205,10 +205,6 @@ export const initializeAssistantSDK = ({
             }
 
             assistantReady = true;
-
-            for (const smartAppData of initialSmartAppData) {
-                emitOnData(smartAppData);
-            }
         }
     };
 


### PR DESCRIPTION
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.9.2--canary.226.2d49921cd786c5e5606c4d7e5129cac744d58d0f.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@4.9.2--canary.226.2d49921cd786c5e5606c4d7e5129cac744d58d0f.0
  # or 
  yarn add @sberdevices/assistant-client@4.9.2--canary.226.2d49921cd786c5e5606c4d7e5129cac744d58d0f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
