### PR TITLE
fix: Отправлять current_app вместе с greetings

### DIFF
--- a/src/assistantSdk/assistant.ts
+++ b/src/assistantSdk/assistant.ts
@@ -322,7 +322,7 @@ export const createAssistant = ({ getMeta, ...configuration }: VpsConfiguration 
         initPhrase?: string;
         isFirstSession?: boolean;
     } = {}): Promise<SystemMessageDataType | undefined> => {
-        if (!disableGreetings) {
+        if (!disableGreetings && isDefaultApp(app.info)) {
             await client.sendOpenAssistant({ isFirstSession });
         }
 

--- a/src/assistantSdk/client/client.ts
+++ b/src/assistantSdk/client/client.ts
@@ -57,12 +57,14 @@ export const createClient = (
     };
 
     /** отправляет приветствие */
-    const sendOpenAssistant = (
+    const sendOpenAssistant = async (
         { isFirstSession }: { isFirstSession: boolean } = { isFirstSession: false },
     ): Promise<SystemMessageDataType> => {
         // eslint-disable-next-line @typescript-eslint/camelcase
         const data = isFirstSession ? { is_first_session: true } : {};
-        return waitForAnswer(sendData(data, 'OPEN_ASSISTANT'));
+        const meta = provideMeta ? await provideMeta() : {};
+
+        return waitForAnswer(sendData({ ...meta, ...data }, 'OPEN_ASSISTANT'));
     };
 
     /** вызывает sendSystemMessage, куда подкладывает мету */


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.10.1--canary.233.0ca3f2bd9effb360e200d88bfbbd3c292c54c402.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@4.10.1--canary.233.0ca3f2bd9effb360e200d88bfbbd3c292c54c402.0
  # or 
  yarn add @sberdevices/assistant-client@4.10.1--canary.233.0ca3f2bd9effb360e200d88bfbbd3c292c54c402.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
