### PR TITLE
fix: объявлять appInitialData в фрейме

### DIFF
--- a/src/createAssistant.ts
+++ b/src/createAssistant.ts
@@ -45,6 +45,7 @@ if (typeof window !== 'undefined' && inIframe()) {
         window.top?.postMessage(JSON.stringify(action), '*');
     };
 
+    window.appInitialData = [];
     window.AssistantHost = {
         sendDataContainer(json: string) {
             postMessage({ type: 'sendDataContainer', payload: json });

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -249,7 +249,7 @@ export interface AssistantHost {
 }
 
 export interface AssistantWindow {
-    AssistantHost?: AssistantHost;
+    AssistantHost: AssistantHost;
     AssistantClient?: AssistantClient;
     appInitialData: Array<AssistantClientCommand>;
     appRecoveryState: unknown;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.14.1--canary.250.bfb9b464275221f9b5d0e158358c7c6486151fe4.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@4.14.1--canary.250.bfb9b464275221f9b5d0e158358c7c6486151fe4.0
  # or 
  yarn add @sberdevices/assistant-client@4.14.1--canary.250.bfb9b464275221f9b5d0e158358c7c6486151fe4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
