### PR TITLE
feat: Записывать версию assistant-client в window

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -5,6 +5,7 @@ export declare global {
     interface Window extends AssistantWindow {}
 
     interface Window {
+        __ASSISTANT_CLIENT__: { version: string };
         webkitAudioContext?: new () => AudioContext;
     }
 }

--- a/src/createAssistant.ts
+++ b/src/createAssistant.ts
@@ -346,4 +346,7 @@ export const createAssistant = <A extends AssistantSmartAppData>({
     };
 };
 
+// eslint-disable-next-line no-underscore-dangle
+window.__ASSISTANT_CLIENT__ = { version: 'process.env.APP_VERSION' };
+
 export * from './typings';


### PR DESCRIPTION
Closes #240 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.15.0--canary.251.cb8d48a2fd642ce383c930d67c62e8422123973c.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@4.15.0--canary.251.cb8d48a2fd642ce383c930d67c62e8422123973c.0
  # or 
  yarn add @sberdevices/assistant-client@4.15.0--canary.251.cb8d48a2fd642ce383c930d67c62e8422123973c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
