### PR TITLE
fix: изменен рейндж версии react в peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,8 @@
         "webpack": "4.44.2"
     },
     "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "react": ">=16.8.0 || ^17.0.1",
+        "react-dom": ">=16.8. || ^17.0.10"
     },
     "files": [
         "dist",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.16.1--canary.257.f9cea8ce416d0871507b4c97eb971781a2531a5f.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@4.16.1--canary.257.f9cea8ce416d0871507b4c97eb971781a2531a5f.0
  # or 
  yarn add @sberdevices/assistant-client@4.16.1--canary.257.f9cea8ce416d0871507b4c97eb971781a2531a5f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
