### PR TITLE
test: Ошибка из-за отсутствия appInitialData

### DIFF
--- a/cypress/integration/createAssistant.spec.ts
+++ b/cypress/integration/createAssistant.spec.ts
@@ -79,12 +79,6 @@ describe('Проверяем createAssistant', () => {
             assistant.sendData({ action: expectedAction, name: expectedName, requestId: expectedRequestId });
         });
 
-    it('Не падать без appInitialData', (done) => {
-        window.appInitialData = undefined;
-        initAssistant();
-        done();
-    });
-
     it('Проверяем автовызов AssistantHost.ready', async () => {
         cy.spy(window.AssistantHost, 'ready');
         initAssistant();
@@ -248,5 +242,18 @@ describe('Проверяем createAssistant', () => {
 
         expect(appInitialData).to.deep.equals(initialData);
         expect(onData).to.not.called;
+    });
+
+    it('Не падать без appInitialData', () => {
+        cy.spy(window.AssistantHost, 'ready');
+
+        window.appInitialData = undefined;
+        const assistant = initAssistant({ ready: false });
+
+        const appInitialData = assistant.getInitialData();
+        assistant.ready();
+
+        expect(appInitialData).to.deep.equals([]);
+        expect(window.AssistantHost.ready).to.calledOnce;
     });
 });


### PR DESCRIPTION
Closes #234 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.17.2--canary.259.0ac7aca64257c5abc68213a662b050666c0eb68e.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/assistant-client@4.17.2--canary.259.0ac7aca64257c5abc68213a662b050666c0eb68e.0
  # or 
  yarn add @sberdevices/assistant-client@4.17.2--canary.259.0ac7aca64257c5abc68213a662b050666c0eb68e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
